### PR TITLE
Moves `initialize` to `my`

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -45,6 +45,9 @@ define(function(){
 	 * @return {object}
 	 */
 	function object(spec, my) {
+		spec = spec || {};
+		my = my || {};
+
 		var that = {};
 
 		that.klass = object;
@@ -52,7 +55,7 @@ define(function(){
 		/**
 		 * initialize is called by the framework upon object instantiation.
 		 */
-		that.initialize = function() {};
+		my.initialize = function() {};
 
 		/**
 		 * Throws an error because the method should have been overridden.
@@ -119,7 +122,7 @@ define(function(){
 			});
 
 			builder(instance, spec, my);
-			instance.initialize();
+			my.initialize();
 
 			return instance;
 		}

--- a/test/inheritanceTest.js
+++ b/test/inheritanceTest.js
@@ -7,7 +7,7 @@ define(function(require) {
 
     test('Methods should be inherited', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.getName = function() {
@@ -27,7 +27,7 @@ define(function(require) {
 
 	test('Methods can be overridden', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.getName = function() {
@@ -51,7 +51,7 @@ define(function(require) {
 
 	test('Protected methods should be inherited', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.toString = function() {
@@ -71,7 +71,7 @@ define(function(require) {
 
 	test('Protected methods can be overridden', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.toString = function() {

--- a/test/initializationTest.js
+++ b/test/initializationTest.js
@@ -9,7 +9,7 @@ define(function(require) {
 		var initialized = false;
 
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				initialized = true;
 			};
 		});

--- a/test/superTest.js
+++ b/test/superTest.js
@@ -7,7 +7,7 @@ define(function(require) {
 
     test('super can be called within public methods', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.getName = function() {
@@ -28,7 +28,7 @@ define(function(require) {
 
 	test('super can be called within protected methods', function() {
 		var animal = object.subclass(function(that, spec, my) {
-			that.initialize = function() {
+			my.initialize = function() {
 				my.name = spec.name;
 			};
 			that.toString = function() {


### PR DESCRIPTION
src/object (that.initialize): Remove
src/object (my.initialize): Add
src/object: Ensure `spec` & `my` are correctly initialized

test/inheritanceTest.js:
test/initializationTest.js:
test/superTest.js: Fix tests by moving `initialize` on `my`